### PR TITLE
fix: save all asset holdings to storage instead of the last network in the list

### DIFF
--- a/src/extension/services/AccountService.ts
+++ b/src/extension/services/AccountService.ts
@@ -190,6 +190,7 @@ export default class AccountService {
         Record<string, IAccountInformation>
       >(
         (acc, value) => ({
+          ...acc,
           [value]: this.sanitizeAccountInformation(
             account.networkInformation[value]
           ),
@@ -200,6 +201,7 @@ export default class AccountService {
         Record<string, IAccountTransactions>
       >(
         (acc, value) => ({
+          ...acc,
           [value]: this.sanitizeAccountTransactions(
             account.networkTransactions[value]
           ),


### PR DESCRIPTION
<!--
The title should summarise what the purpose of this change,

⚠️**NOTE:** The title must conform to the conventional commit message format outlined in CONTRIBUTING.md document, at the root of the project. This is to ensure the merge commit to the main branch is picked up by the CI and creates an entry in the CHANGELOG.md.
-->

# Description
<!-- Describe your changes in detail -->
* When santizing an account for saving to storage, include all network configurations, not just the last on in the list

# Type of change
<!-- What type of change does this change introduce? Put an 'x' in all the boxes that apply. -->

- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🏗️ Build configuration (CI configuration, scaffolding etc.)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 📝 Documentation update(s)
- [ ] 📦 Dependency update(s)
- [ ] 👩🏽‍💻 Improve developer experience
- [ ] ⚡ Improve performance
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] ♻ Refactor
- [ ] ⏪ Revert changes
- [ ] 🧪 New tests or updates to existing tests
