### PR TITLE
ci: auomatically upload and publish to the edge add on store

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.yml
@@ -51,8 +51,10 @@ body:
       label: What browser are you seeing the problem on?
       multiple: true
       options:
-        - Firefox
+        - Brave
         - Chrome
+        - Edge
+        - Firefox
     validations:
       required: true
   # description

--- a/.github/workflows/publish_to_chrome_web_store.yml
+++ b/.github/workflows/publish_to_chrome_web_store.yml
@@ -26,5 +26,5 @@ jobs:
           CHROME_WEB_STORE_API_CLIENT_SECRET: ${{ secrets.CHROME_WEB_STORE_API_CLIENT_SECRET }}
           CHROME_WEB_STORE_API_REFRESH_TOKEN: ${{ secrets.CHROME_WEB_STORE_API_REFRESH_TOKEN }}
         run: |
-          ./bin/publish_to_chrome_web_store.sh ${{ vars.CHROME_WEB_STORE_ID }} ${{ env.asset_prefix }}.zip
+          ./bin/publish_to_chrome_web_store.sh ${{ vars.CHROME_WEB_STORE_ITEM_ID }} ${{ env.asset_prefix }}.zip
 

--- a/.github/workflows/publish_to_microsoft_edge_add_on.yml
+++ b/.github/workflows/publish_to_microsoft_edge_add_on.yml
@@ -1,0 +1,30 @@
+name: "Publish To Microsoft Edge Add-ons"
+
+on:
+  release:
+    types: [released] # triggered on main branch releases
+
+env:
+  asset_prefix: "kibisis-edge"
+
+jobs:
+  deploy:
+    name: "Deploy"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "🛎 Checkout"
+        uses: actions/checkout@v3
+      - name: "📥 Download Latest Release Asset"
+        uses: ./.github/actions/download-latest-release-asset
+        with:
+          asset_prefix: ${{ env.asset_prefix }}
+          github_token: ${{ secrets.WRITE_REPOS_TOKEN }}
+      - name: "🚀 Publish"
+        env:
+          # set in the Settings > Secrets and variables > Actions > Secrets
+          MICROSOFT_EDGE_ADD_ONS_API_CLIENT_ID: ${{ secrets.MICROSOFT_EDGE_ADD_ONS_API_CLIENT_ID }}
+          MICROSOFT_EDGE_ADD_ONS_API_CLIENT_SECRET: ${{ secrets.MICROSOFT_EDGE_ADD_ONS_API_CLIENT_SECRET }}
+          MICROSOFT_EDGE_ADD_ONS_API_ACCESS_TOKEN_URL: ${{ secrets.MICROSOFT_EDGE_ADD_ONS_API_ACCESS_TOKEN_URL }}
+        run: |
+          ./bin/publish_to_microsoft_edge_add_ons.sh ${{ vars.MICROSOFT_EDGE_ADD_ON_PRODUCT_ID }} ${{ env.asset_prefix }}.zip
+

--- a/README.md
+++ b/README.md
@@ -27,11 +27,17 @@
 </p>
 
 <p align="center">
-  <a href="https://addons.mozilla.org/en-GB/firefox/addon/kibisis" target="_blank">
-    <img src="https://img.shields.io/amo/v/kibisis?logo=firefox" alt="Mozilla add-on" />
-  </a>
   <a href="https://chromewebstore.google.com/detail/kibisis/hcgejekffjilpgbommjoklpneekbkajb" target="_blank">
-    <img alt="Chrome Web Store Version" src="https://img.shields.io/chrome-web-store/v/hcgejekffjilpgbommjoklpneekbkajb?logo=googlechrome">
+    <img alt="Chrome Web Store Version" src="https://img.shields.io/chrome-web-store/v/hcgejekffjilpgbommjoklpneekbkajb?logo=googlechrome&logoColor=%23FFCE44&color=%23FFCE44">
+  </a>
+
+  <a href="https://microsoftedge.microsoft.com/addons/detail/kibisis/bajncpocmkioafbijldokfbjajelkbmc" target="_blank">
+    <img alt="Microsoft Edge Add-on Version" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fmicrosoftedge.microsoft.com%2Faddons%2Fgetproductdetailsbycrxid%2Fbajncpocmkioafbijldokfbjajelkbmc%3Fhl%3Den-GB%26gl%3DGB&query=%24.version&prefix=v&logo=microsoftedge&logoColor=%230078D7&label=microsoft%20edge%20add-on&color=%230078D7" />
+  </a>
+
+  <a href="https://addons.mozilla.org/en-GB/firefox/addon/kibisis" target="_blank">
+    <img alt="Mozilla Add-on Version" src="https://img.shields.io/amo/v/kibisis?logo=firefox&logoColor=%23FF7139&color=%23FF7139
+" />
   </a>
 </p>
 

--- a/bin/publish_to_chrome_web_store.sh
+++ b/bin/publish_to_chrome_web_store.sh
@@ -4,19 +4,19 @@ SCRIPT_DIR=$(dirname "${0}")
 
 source "${SCRIPT_DIR}/set_vars.sh"
 
-# Public: Gets an access token and uploads & publishes the package to the Chrome Web Store API.
+# Public: Gets an access token and uploads & publishes the package to the Chrome Web Store.
 #
 # Required environment variables:
 # * CHROME_WEB_STORE_API_CLIENT_ID - a client ID for the Chrome Web Store API.
 # * CHROME_WEB_STORE_API_CLIENT_SECRET - a client secret for the Chrome Web Store API.
 # * CHROME_WEB_STORE_API_REFRESH_TOKEN - a refresh token to get an access token for the Chrome Web Store API.
 #
-# $1 - Chrome item ID.
+# $1 - chrome item id.
 # $2 - path to zip build.
 #
 # Examples
 #
-#   ./bin/publish_to_chrome.sh "/path/to/file.zip"
+#   ./bin/publish_to_chrome_web_store.sh "${CHROME_WEB_STORE_ITEM_ID}" "/path/to/file.zip"
 #
 # Returns exit code 0 if successful, or 1 the zip file does not exist, the item id is missing, or if the required
 # environment variables are missing.
@@ -29,17 +29,17 @@ function main {
   set_vars
 
   if [ -z "${1}" ]; then
-    printf "%b no item id provided, use: ./bin/publish_to_chrome.sh [item_id] [path_to_zip] \n" "${ERROR_PREFIX}"
+    printf "%b no item id provided, use: ./bin/publish_to_chrome_web_store.sh [item_id] [path_to_zip] \n" "${ERROR_PREFIX}"
     exit 1
   fi
 
   if [ -z "${2}" ]; then
-    printf "%b no zip path specified, use: ./bin/publish_to_chrome.sh [item_id] [path_to_zip] \n" "${ERROR_PREFIX}"
+    printf "%b no zip path specified, use: ./bin/publish_to_chrome_web_store.sh [item_id] [path_to_zip] \n" "${ERROR_PREFIX}"
     exit 1
   fi
 
   if [ ! -f "${2}" ]; then
-    printf "%b zip file not found at ${1} \n" "${ERROR_PREFIX}"
+    printf "%b zip file not found at ${2} \n" "${ERROR_PREFIX}"
     exit 1
   fi
 

--- a/bin/publish_to_microsoft_edge_add_ons.sh
+++ b/bin/publish_to_microsoft_edge_add_ons.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+SCRIPT_DIR=$(dirname "${0}")
+
+source "${SCRIPT_DIR}/set_vars.sh"
+
+# Public: Gets an access token and uploads & publishes the package to the Microsoft Edge Add-ons.
+#
+# Required environment variables:
+# * MICROSOFT_EDGE_ADD_ONS_API_CLIENT_ID - a client ID for the Microsoft Edge Add-ons API.
+# * MICROSOFT_EDGE_ADD_ONS_API_CLIENT_SECRET - a client secret for the Microsoft Edge Add-ons API.
+# * MICROSOFT_EDGE_ADD_ONS_API_ACCESS_TOKEN_URL - an access token URL for the Microsoft Edge Add-ons API.
+#
+# $1 - product id.
+# $2 - path to zip build.
+#
+# Examples
+#
+#   ./bin/publish_to_microsoft_edge_add_ons.sh "${MICROSOFT_EDGE_ADD_ON_PRODUCT_ID}" "/path/to/file.zip"
+#
+# Returns exit code 0 if successful, or 1 the zip file does not exist, the item id is missing, or if the required
+# environment variables are missing.
+function main {
+  local access_token
+  local access_token_result
+  local publish_result
+  local upload_result
+
+  set_vars
+
+  if [ -z "${1}" ]; then
+    printf "%b no product id provided, use: ./bin/publish_to_microsoft_edge_add_ons.sh [product_id] [path_to_zip] \n" "${ERROR_PREFIX}"
+    exit 1
+  fi
+
+  if [ -z "${2}" ]; then
+    printf "%b no zip path specified, use: ./bin/publish_to_microsoft_edge_add_ons.sh [product_id] [path_to_zip] \n" "${ERROR_PREFIX}"
+    exit 1
+  fi
+
+  if [ ! -f "${2}" ]; then
+    printf "%b zip file not found at ${2} \n" "${ERROR_PREFIX}"
+    exit 1
+  fi
+
+  if [ -z "${MICROSOFT_EDGE_ADD_ONS_API_CLIENT_ID}" ]; then
+    printf "%b client id not provided \n" "${ERROR_PREFIX}"
+    exit 1
+  fi
+
+  if [ -z "${MICROSOFT_EDGE_ADD_ONS_API_CLIENT_SECRET}" ]; then
+    printf "%b client secret not provided \n" "${ERROR_PREFIX}"
+    exit 1
+  fi
+
+  if [ -z "${MICROSOFT_EDGE_ADD_ONS_API_ACCESS_TOKEN_URL}" ]; then
+    printf "%b access token url not provided \n" "${ERROR_PREFIX}"
+    exit 1
+  fi
+
+  printf "%b getting access token... \n" "${INFO_PREFIX}"
+
+  access_token_result=$(curl \
+    -s \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    -X POST \
+    -d "client_id=${MICROSOFT_EDGE_ADD_ONS_API_CLIENT_ID}" \
+    -d "scope=https://api.addons.microsoftedge.microsoft.com/.default" \
+    -d "client_secret=${MICROSOFT_EDGE_ADD_ONS_API_CLIENT_SECRET}" \
+    -d "grant_type=client_credentials" \
+    "${MICROSOFT_EDGE_ADD_ONS_API_ACCESS_TOKEN_URL}")
+
+  # check for errors
+  if [ $(jq 'has("error")' <<< "${access_token_result}") == true ]; then
+    printf "%b failed to get access token: $(jq '.error_description' <<< "${access_token_result}") \n" "${ERROR_PREFIX}"
+    exit 1
+  fi
+
+  access_token=$(jq '.access_token' <<< "${access_token_result}")
+
+  printf "%b uploading new package... \n" "${INFO_PREFIX}"
+
+  upload_result=$(curl \
+    -H "Authorization: Bearer ${access_token}" \
+    -H "Content-Type: application/zip" \
+    -X POST \
+    -T "${2}" \
+    -v \
+    "https://api.addons.microsoftedge.microsoft.com/v1/products/${1}/submissions/draft/package")
+
+  # check for errors
+  if [ $(jq 'has("error")' <<< "${upload_result}") == true ]; then
+    printf "%b failed to upload new package: $(jq '.error.status' <<< "${upload_result}") \n" "${ERROR_PREFIX}"
+    exit 1
+  fi
+
+  printf "%b successfully uploaded package: ${2} \n" "${INFO_PREFIX}"
+
+  printf "%b publishing package... \n" "${INFO_PREFIX}"
+
+  publish_result=$(curl \
+    -s \
+    -H "Authorization: Bearer ${access_token}"  \
+    -X POST \
+    -v \
+    "https://api.addons.microsoftedge.microsoft.com/v1/products/${1}/submissions")
+
+  # check for errors
+  if [ $(jq 'has("error")' <<< "${publish_result}") == true ]; then
+    printf "%b failed to publish package: $(jq '.error.status' <<< "${publish_result}") \n" "${ERROR_PREFIX}"
+    exit 1
+  fi
+
+  printf "%b successfully published package: ${2} \n" "${INFO_PREFIX}"
+
+  exit 0
+}
+
+# And so, it begins...
+main "$1" "$2"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "avm",
     "blockchain",
     "browser",
+    "chrome",
+    "edge",
     "firefox",
     "voi",
     "wallet"


### PR DESCRIPTION
<!--
The title should summarise what the purpose of this change,

⚠️**NOTE:** The title must conform to the conventional commit message format outlined in CONTRIBUTING.md document, at the root of the project. This is to ensure the merge commit to the main branch is picked up by the CI and creates an entry in the CHANGELOG.md.
-->

# Description
<!-- Describe your changes in detail -->
* Update references to the `CHROME_WEB_STORE_ID` environment variable to `CHROME_WEB_STORE_ITEM_ID`
* Add Brave and Edge to the bug report issue template
* Add workflow and script to get an access token, upload & publish new package
* Add `chrome` and `edge` to the keywords list in the package.json
* Update `README.md` with the Microsoft Edge Add-on badge

# Type of change
<!-- What type of change does this change introduce? Put an 'x' in all the boxes that apply. -->

- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🏗️ Build configuration (CI configuration, scaffolding etc.)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 📝 Documentation update(s)
- [ ] 📦 Dependency update(s)
- [ ] 👩🏽‍💻 Improve developer experience
- [ ] ⚡ Improve performance
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] ♻ Refactor
- [ ] ⏪ Revert changes
- [ ] 🧪 New tests or updates to existing tests
