### PR TITLE
feat: dont allow adding of standard asset if account balance is below the minimum balance requirement

### DIFF
--- a/src/extension/constants/Network.ts
+++ b/src/extension/constants/Network.ts
@@ -1,0 +1,1 @@
+export const MINIMUM_BALANCE_REQUIREMENT: number = 100000; // 100,000 microAlgos / 0.1 algos

--- a/src/extension/constants/index.ts
+++ b/src/extension/constants/index.ts
@@ -7,6 +7,7 @@ export * from './Encryption';
 export * from './Keys';
 export * from './Links';
 export * from './Limits';
+export * from './Network';
 export * from './Routes';
 export * from './Styles';
 export * from './URIs';

--- a/src/extension/enums/ErrorCodeEnum.ts
+++ b/src/extension/enums/ErrorCodeEnum.ts
@@ -17,6 +17,7 @@ enum ErrorCodeEnum {
 
   // transaction
   FailedToSendTransactionError = 4000,
+  NotEnoughMinimumBalanceError = 4001,
 
   // contract (application)
   InvalidABIContractError = 5000,

--- a/src/extension/errors/NotEnoughMinimumBalanceError.ts
+++ b/src/extension/errors/NotEnoughMinimumBalanceError.ts
@@ -1,0 +1,11 @@
+// enums
+import { ErrorCodeEnum } from '../enums';
+
+// errors
+import BaseExtensionError from './BaseExtensionError';
+
+export default class NotEnoughMinimumBalanceError extends BaseExtensionError {
+  public readonly code: ErrorCodeEnum =
+    ErrorCodeEnum.NotEnoughMinimumBalanceError;
+  public readonly name: string = 'NotEnoughMinimumBalanceError';
+}

--- a/src/extension/errors/index.ts
+++ b/src/extension/errors/index.ts
@@ -10,6 +10,7 @@ export { default as InvalidPasswordError } from './InvalidPasswordError';
 export { default as MalformedDataError } from './MalformedDataError';
 export { default as NetworkConnectionError } from './NetworkConnectionError';
 export { default as NetworkNotSelectedError } from './NetworkNotSelectedError';
+export { default as NotEnoughMinimumBalanceError } from './NotEnoughMinimumBalanceError';
 export { default as OfflineError } from './OfflineError';
 export { default as ParsingError } from './ParsingError';
 export { default as PrivateKeyAlreadyExistsError } from './PrivateKeyAlreadyExistsError';

--- a/src/extension/modals/AddAssetModal/AddAssetModal.tsx
+++ b/src/extension/modals/AddAssetModal/AddAssetModal.tsx
@@ -429,7 +429,7 @@ const AddAssetModal: FC<IProps> = ({ onClose }: IProps) => {
     dispatch(setSelectedAsset(asset));
   // renders
   const renderContent = () => {
-    if (selectedNetwork) {
+    if (selectedNetwork && account) {
       if (selectedAsset) {
         switch (selectedAsset.type) {
           case AssetTypeEnum.ARC0200:
@@ -451,9 +451,10 @@ const AddAssetModal: FC<IProps> = ({ onClose }: IProps) => {
 
             return (
               <AddAssetModalStandardAssetSummaryContent
+                account={account}
                 accounts={accounts}
                 asset={selectedAsset}
-                explorer={explorer}
+                blockExplorer={explorer}
                 network={selectedNetwork}
               />
             );

--- a/src/extension/modals/AddAssetModal/AddAssetModalStandardAssetSummaryContent.tsx
+++ b/src/extension/modals/AddAssetModal/AddAssetModalStandardAssetSummaryContent.tsx
@@ -72,11 +72,12 @@ const AddAssetModalStandardAssetSummaryContent: FC<
     calculateMinimumBalanceRequirementForStandardAssets({
       account,
       network,
-      numOfStandardAssets: 1,
     });
   const isEnoughMinimumBalance: boolean = accountBalanceInAtomicUnits.gte(
     minimumBalanceRequirement.plus(minimumTransactionFee)
   );
+  const accountAddress: string =
+    AccountService.convertPublicKeyToAlgorandAddress(account.publicKey);
   // handlers
   const handleMoreInformationToggle = (value: boolean) =>
     value ? onOpen() : onClose();
@@ -148,25 +149,25 @@ const AddAssetModalStandardAssetSummaryContent: FC<
             </HStack>
           </PageItem>
 
-          {/*creator account*/}
-          <PageItem fontSize="sm" label={t<string>('labels.creatorAccount')}>
+          {/*account*/}
+          <PageItem fontSize="sm" label={t<string>('labels.account')}>
             <HStack spacing={0}>
               <AddressDisplay
-                address={asset.creator}
-                ariaLabel="Creator address"
+                address={accountAddress}
+                ariaLabel="Accoun to add the standard asset to"
                 color={subTextColor}
                 fontSize="sm"
                 network={network}
               />
 
               {/*open in explorer button*/}
-              {!isAccountKnown(accounts, asset.creator) && blockExplorer && (
+              {blockExplorer && (
                 <OpenTabIconButton
                   size="sm"
                   tooltipLabel={t<string>('captions.openOn', {
                     name: blockExplorer.canonicalName,
                   })}
-                  url={`${blockExplorer.baseUrl}${blockExplorer.accountPath}/${asset.creator}`}
+                  url={`${blockExplorer.baseUrl}${blockExplorer.accountPath}/${accountAddress}`}
                 />
               )}
             </HStack>
@@ -297,6 +298,34 @@ const AddAssetModalStandardAssetSummaryContent: FC<
                     })}
                   </Text>
                 </Tooltip>
+              </PageItem>
+
+              {/*creator account*/}
+              <PageItem
+                fontSize="sm"
+                label={t<string>('labels.creatorAccount')}
+              >
+                <HStack spacing={0}>
+                  <AddressDisplay
+                    address={asset.creator}
+                    ariaLabel="Creator address"
+                    color={subTextColor}
+                    fontSize="sm"
+                    network={network}
+                  />
+
+                  {/*open in explorer button*/}
+                  {!isAccountKnown(accounts, asset.creator) &&
+                    blockExplorer && (
+                      <OpenTabIconButton
+                        size="sm"
+                        tooltipLabel={t<string>('captions.openOn', {
+                          name: blockExplorer.canonicalName,
+                        })}
+                        url={`${blockExplorer.baseUrl}${blockExplorer.accountPath}/${asset.creator}`}
+                      />
+                    )}
+                </HStack>
               </PageItem>
 
               {/*default frozen*/}

--- a/src/extension/modals/AddAssetModal/types/IAddAssetModalStandardAssetSummaryContentProps.ts
+++ b/src/extension/modals/AddAssetModal/types/IAddAssetModalStandardAssetSummaryContentProps.ts
@@ -1,0 +1,17 @@
+// types
+import type {
+  IAccount,
+  IBlockExplorer,
+  INetworkWithTransactionParams,
+  IStandardAsset,
+} from '@extension/types';
+
+interface IAddAssetModalStandardAssetSummaryContentProps {
+  account: IAccount;
+  accounts: IAccount[];
+  asset: IStandardAsset;
+  blockExplorer: IBlockExplorer | null;
+  network: INetworkWithTransactionParams;
+}
+
+export default IAddAssetModalStandardAssetSummaryContentProps;

--- a/src/extension/modals/AddAssetModal/types/index.ts
+++ b/src/extension/modals/AddAssetModal/types/index.ts
@@ -1,0 +1,1 @@
+export type { default as IAddAssetModalStandardAssetSummaryContentProps } from './IAddAssetModalStandardAssetSummaryContentProps';

--- a/src/extension/translations/en.ts
+++ b/src/extension/translations/en.ts
@@ -121,6 +121,7 @@ const translation: IResourceLanguage = {
     maximumNativeCurrencyTransactionAmount:
       'The maximum {{nativeCurrencyCode}} amount is calculated by: the balance ({{balance}}), minus the minimum balance needed to keep the account open ({{minBalance}}), minus the minimum transaction fee ({{minFee}})',
     minimumBalance: `Minimum balance is {{amount}} {{code}}. Based on the account configuration, this is the minimum balance needed to keep the account open.`,
+    minimumBalanceTooLow: `You do not have enough balance to complete this transaction. You need at least {{cost}} {{symbol}}. Your current balance is {{balance}} {{symbol}}.`,
     mustEnterPasswordToAuthorizeOptIn:
       'You must enter your password to authorize an opt-in transaction.',
     mustEnterPasswordToConfirm: 'You must enter your password to confirm.',

--- a/src/extension/translations/en.ts
+++ b/src/extension/translations/en.ts
@@ -195,6 +195,7 @@ const translation: IResourceLanguage = {
       code_1002: `Failed to parse the "{{type}}" data.`,
       code_2000: 'The password seems to be invalid.',
       code_2003: 'This account already exists.',
+      code_4001: 'Your balance will fall below the minimum balance required.',
       code_6000: 'There was an error starting the camera.',
     },
     inputs: {
@@ -213,6 +214,7 @@ const translation: IResourceLanguage = {
       code_1002: '1002 Parsing Error',
       code_2000: '2000 Invalid Password',
       code_2003: '2003 Account Already Exists',
+      code_4001: '4001 Minimum Balance Required',
       code_6000: '6000 Camera Error',
     },
   },

--- a/src/extension/utils/calculateMinimumBalanceRequirementForStandardAssets/calculateMinimumBalanceRequirementForStandardAssets.ts
+++ b/src/extension/utils/calculateMinimumBalanceRequirementForStandardAssets/calculateMinimumBalanceRequirementForStandardAssets.ts
@@ -1,0 +1,38 @@
+import BigNumber from 'bignumber.js';
+
+// constants
+import { MINIMUM_BALANCE_REQUIREMENT } from '@extension/constants';
+
+// service
+import AccountService from '@extension/services/AccountService';
+
+// types
+import type { IAccountInformation } from '@extension/types';
+import type { IOptions } from './types';
+
+/**
+ * Convenience function that calculates the minimum balance requirement for a number of standard assets.
+ * @param {IOptions} options - contains the account, network and the number of standard assets.
+ * @returns {BigNumber} the minimum balance requirement for the specified number of standard assets.
+ */
+export default function calculateMinimumBalanceRequirementForStandardAssets({
+  account,
+  network,
+  numOfStandardAssets,
+}: IOptions): BigNumber {
+  const accountInformation: IAccountInformation | null =
+    AccountService.extractAccountInformationForNetwork(account, network);
+  let accountMinimumBalance: BigNumber = new BigNumber(
+    MINIMUM_BALANCE_REQUIREMENT
+  );
+
+  // if we can't get the account information, return the minimum amount without standard assets
+  if (accountInformation) {
+    accountMinimumBalance = new BigNumber(accountInformation.minAtomicBalance);
+  }
+
+  // minimum account balance + (minimum balance requirement * number of standard assets)
+  return accountMinimumBalance.plus(
+    new BigNumber(MINIMUM_BALANCE_REQUIREMENT).multipliedBy(numOfStandardAssets)
+  );
+}

--- a/src/extension/utils/calculateMinimumBalanceRequirementForStandardAssets/calculateMinimumBalanceRequirementForStandardAssets.ts
+++ b/src/extension/utils/calculateMinimumBalanceRequirementForStandardAssets/calculateMinimumBalanceRequirementForStandardAssets.ts
@@ -18,7 +18,7 @@ import type { IOptions } from './types';
 export default function calculateMinimumBalanceRequirementForStandardAssets({
   account,
   network,
-  numOfStandardAssets,
+  numOfStandardAssets = 1,
 }: IOptions): BigNumber {
   const accountInformation: IAccountInformation | null =
     AccountService.extractAccountInformationForNetwork(account, network);

--- a/src/extension/utils/calculateMinimumBalanceRequirementForStandardAssets/index.ts
+++ b/src/extension/utils/calculateMinimumBalanceRequirementForStandardAssets/index.ts
@@ -1,0 +1,1 @@
+export { default } from './calculateMinimumBalanceRequirementForStandardAssets';

--- a/src/extension/utils/calculateMinimumBalanceRequirementForStandardAssets/types/IOptions.ts
+++ b/src/extension/utils/calculateMinimumBalanceRequirementForStandardAssets/types/IOptions.ts
@@ -4,7 +4,7 @@ import type { IAccount, INetwork } from '@extension/types';
 interface IOptions {
   account: IAccount;
   network: INetwork;
-  numOfStandardAssets: number;
+  numOfStandardAssets?: number;
 }
 
 export default IOptions;

--- a/src/extension/utils/calculateMinimumBalanceRequirementForStandardAssets/types/IOptions.ts
+++ b/src/extension/utils/calculateMinimumBalanceRequirementForStandardAssets/types/IOptions.ts
@@ -1,0 +1,10 @@
+// types
+import type { IAccount, INetwork } from '@extension/types';
+
+interface IOptions {
+  account: IAccount;
+  network: INetwork;
+  numOfStandardAssets: number;
+}
+
+export default IOptions;

--- a/src/extension/utils/calculateMinimumBalanceRequirementForStandardAssets/types/index.ts
+++ b/src/extension/utils/calculateMinimumBalanceRequirementForStandardAssets/types/index.ts
@@ -1,0 +1,1 @@
+export type { default as IOptions } from './IOptions';


### PR DESCRIPTION
<!--
The title should summarise what the purpose of this change,

⚠️**NOTE:** The title must conform to the conventional commit message format outlined in CONTRIBUTING.md document, at the root of the project. This is to ensure the merge commit to the main branch is picked up by the CI and creates an entry in the CHANGELOG.md.
-->

# Description
<!-- Describe your changes in detail -->
* Add warning icon if the account balance does not exceed the minimum balance requirement to add a standard asset 
* Throw a `NotEnoughMinimumBalanceError` of the account balance does not exceed the minimum balance requirement when attempting to add a standard asset

# Type of change
<!-- What type of change does this change introduce? Put an 'x' in all the boxes that apply. -->

- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🏗️ Build configuration (CI configuration, scaffolding etc.)
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 📝 Documentation update(s)
- [ ] 📦 Dependency update(s)
- [ ] 👩🏽‍💻 Improve developer experience
- [ ] ⚡ Improve performance
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] ♻ Refactor
- [ ] ⏪ Revert changes
- [ ] 🧪 New tests or updates to existing tests
