### PR TITLE
fix: set focus to new app window upon creation

### DIFF
--- a/src/extension/services/AppWindowManagerService/types/ICreateWindowOptions.ts
+++ b/src/extension/services/AppWindowManagerService/types/ICreateWindowOptions.ts
@@ -1,0 +1,11 @@
+// types
+import { AppTypeEnum } from '@extension/enums';
+
+interface ICreateWindowOptions {
+  left?: number;
+  searchParams?: URLSearchParams;
+  top?: number;
+  type: AppTypeEnum;
+}
+
+export default ICreateWindowOptions;

--- a/src/extension/services/AppWindowManagerService/types/index.ts
+++ b/src/extension/services/AppWindowManagerService/types/index.ts
@@ -1,1 +1,2 @@
 export type { default as ICreateOptions } from './ICreateOptions';
+export type { default as ICreateWindowOptions } from './ICreateWindowOptions';

--- a/src/extension/services/BackgroundEventListener/BackgroundEventListener.ts
+++ b/src/extension/services/BackgroundEventListener/BackgroundEventListener.ts
@@ -1,11 +1,7 @@
 import browser, { Alarms, Tabs, Windows } from 'webextension-polyfill';
 
 // constants
-import {
-  DEFAULT_POPUP_HEIGHT,
-  DEFAULT_POPUP_WIDTH,
-  PASSWORD_LOCK_ALARM,
-} from '@extension/constants';
+import { PASSWORD_LOCK_ALARM } from '@extension/constants';
 
 // enums
 import { AppTypeEnum } from '@extension/enums';
@@ -119,9 +115,7 @@ export default class BackgroundEventListener {
     const _functionName: string = 'onExtensionClick';
     const isInitialized: boolean = await this.privateKeyService.isInitialized();
     let mainAppWindows: IAppWindow[];
-    let mainWindow: Windows.Window;
     let registrationAppWindows: IAppWindow[];
-    let registrationWindow: Windows.Window;
 
     this.logger?.debug(
       `${BackgroundEventListener.name}#${_functionName}(): browser extension clicked`
@@ -156,18 +150,9 @@ export default class BackgroundEventListener {
       await this.storageManager.removeAll();
 
       // if there is no registration app window up, we can open a new one
-      registrationWindow = await browser.windows.create({
-        height: DEFAULT_POPUP_HEIGHT,
-        type: 'popup',
-        url: 'registration-app.html',
-        width: DEFAULT_POPUP_WIDTH,
+      await this.appWindowManagerService.createWindow({
+        type: AppTypeEnum.RegistrationApp,
       });
-
-      // save the registration window to storage
-      return await this.appWindowManagerService.saveByBrowserWindowAndType(
-        registrationWindow,
-        AppTypeEnum.RegistrationApp
-      );
     }
 
     mainAppWindows = await this.appWindowManagerService.getByType(
@@ -192,18 +177,9 @@ export default class BackgroundEventListener {
     );
 
     // if there is no main app window up, we can open the app
-    mainWindow = await browser.windows.create({
-      height: DEFAULT_POPUP_HEIGHT,
-      type: 'popup',
-      url: 'main-app.html',
-      width: DEFAULT_POPUP_WIDTH,
+    await this.appWindowManagerService.createWindow({
+      type: AppTypeEnum.MainApp,
     });
-
-    // save the main app window to storage
-    await this.appWindowManagerService.saveByBrowserWindowAndType(
-      mainWindow,
-      AppTypeEnum.MainApp
-    );
   }
 
   public async onFocusChanged(windowId: number): Promise<void> {


### PR DESCRIPTION
refactor: move window creation to app window service
feat: set app window position to middle of current window

<!--
The title should summarise what the purpose of this change,

⚠️**NOTE:** The title must conform to the conventional commit message format outlined in CONTRIBUTING.md document, at the root of the project. This is to ensure the merge commit to the main branch is picked up by the CI and creates an entry in the CHANGELOG.md.
-->

# Description
<!-- Describe your changes in detail -->
* Move window creation to `AppWindowManagerService`
* Position app window to middle of current window on window creation [Chrome only]
* Set focus to app window on creation

# Type of change
<!-- What type of change does this change introduce? Put an 'x' in all the boxes that apply. -->

- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🏗️ Build configuration (CI configuration, scaffolding etc.)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 📝 Documentation update(s)
- [ ] 📦 Dependency update(s)
- [ ] 👩🏽‍💻 Improve developer experience
- [ ] ⚡ Improve performance
- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ♻ Refactor
- [ ] ⏪ Revert changes
- [ ] 🧪 New tests or updates to existing tests
