### PR TITLE
fix: add auth address when simulating a transaction to get the box references

### DIFF
--- a/src/extension/contracts/ARC0200Contract/types/ITransferOptions.ts
+++ b/src/extension/contracts/ARC0200Contract/types/ITransferOptions.ts
@@ -2,6 +2,7 @@ import BigNumber from 'bignumber.js';
 
 interface ITransferOptions {
   amountInAtomicUnits: BigNumber;
+  authAddress?: string;
   fromAddress: string;
   note?: string;
   toAddress: string;

--- a/src/extension/contracts/BaseContract/types/IDetermineBoxReferencesOptions.ts
+++ b/src/extension/contracts/BaseContract/types/IDetermineBoxReferencesOptions.ts
@@ -2,6 +2,7 @@
 import IBaseApplicationOptions from './IBaseApplicationOptions';
 
 interface IDetermineBoxReferencesOptions extends IBaseApplicationOptions {
+  authAddress?: string;
   fromAddress: string;
 }
 

--- a/src/extension/contracts/BaseContract/types/ISimulateTransaction.ts
+++ b/src/extension/contracts/BaseContract/types/ISimulateTransaction.ts
@@ -2,6 +2,7 @@ import { ABIMethod, Transaction } from 'algosdk';
 
 interface ISimulateTransaction {
   abiMethod: ABIMethod;
+  authAddress?: string;
   transaction: Transaction;
 }
 

--- a/src/extension/utils/createUnsignedARC0200TransferTransactions/createUnsignedARC0200TransferTransactions.ts
+++ b/src/extension/utils/createUnsignedARC0200TransferTransactions/createUnsignedARC0200TransferTransactions.ts
@@ -16,6 +16,7 @@ import type { IOptions } from './types';
 export default async function createUnsignedARC0200TransferTransactions({
   amountInAtomicUnits,
   asset,
+  authAddress,
   fromAddress,
   logger,
   network,
@@ -32,6 +33,9 @@ export default async function createUnsignedARC0200TransferTransactions({
     amountInAtomicUnits: new BigNumber(amountInAtomicUnits),
     fromAddress,
     toAddress,
+    ...(authAddress && {
+      authAddress,
+    }),
     ...(note && {
       note,
     }),

--- a/src/extension/utils/createUnsignedARC0200TransferTransactions/types/IOptions.ts
+++ b/src/extension/utils/createUnsignedARC0200TransferTransactions/types/IOptions.ts
@@ -5,6 +5,7 @@ import type { IARC0200Asset, INetwork } from '@extension/types';
 interface IOptions extends IBaseOptions {
   amountInAtomicUnits: string;
   asset: IARC0200Asset;
+  authAddress: string | null;
   fromAddress: string;
   network: INetwork;
   note: string | null;


### PR DESCRIPTION
<!--
The title should summarise what the purpose of this change,

⚠️**NOTE:** The title must conform to the conventional commit message format outlined in CONTRIBUTING.md document, at the root of the project. This is to ensure the merge commit to the main branch is picked up by the CI and creates an entry in the CHANGELOG.md.
-->

# Description
<!-- Describe your changes in detail -->
* Revert back to using a simulated transaction to get the box references for ARC-0200 contracts
* Add `authAddress` when simulating transactions for rekeyed signer accounts

# Type of change
<!-- What type of change does this change introduce? Put an 'x' in all the boxes that apply. -->

- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🏗️ Build configuration (CI configuration, scaffolding etc.)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 📝 Documentation update(s)
- [ ] 📦 Dependency update(s)
- [ ] 👩🏽‍💻 Improve developer experience
- [ ] ⚡ Improve performance
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] ♻ Refactor
- [ ] ⏪ Revert changes
- [ ] 🧪 New tests or updates to existing tests
