### PR TITLE
fix: move disable whats new modal to object in system info with the version

### DIFF
--- a/src/extension/apps/main/Root.tsx
+++ b/src/extension/apps/main/Root.tsx
@@ -64,9 +64,8 @@ import WhatsNewModal from '@extension/modals/WhatsNewModal';
 import {
   useSelectAccounts,
   useSelectNotificationsShowingConfetti,
-  useSelectSettings,
   useSelectSettingsSelectedNetwork,
-  useSelectSystemInfo,
+  useSelectSystemWhatsNewInfo,
 } from '@extension/selectors';
 
 // types
@@ -78,8 +77,7 @@ const Root: FC = () => {
   const accounts = useSelectAccounts();
   const network = useSelectSettingsSelectedNetwork();
   const showingConfetti = useSelectNotificationsShowingConfetti();
-  const { general } = useSelectSettings();
-  const systemInfo = useSelectSystemInfo();
+  const whatsNewInfo = useSelectSystemWhatsNewInfo();
   // handlers
   const handleAddAssetsModalClose = () => dispatch(resetAddAsset());
   const handleConfirmClose = () => dispatch(setConfirmModal(null));
@@ -125,17 +123,16 @@ const Root: FC = () => {
       dispatch(updateTransactionParamsForSelectedNetworkThunk());
     }
   }, [network]);
-  // if the saved what's new version is null or less than the current version (and the update message is not disabled in the settings), display the modal
+  // if the saved what's new version is null or less than the current version (and the update message is not disabled), display the modal
   useEffect(() => {
     if (
-      systemInfo &&
-      !general.disableWhatsNewModalOnUpdate &&
-      (!systemInfo.whatsNewVersion ||
-        systemInfo.whatsNewVersion !== __VERSION__)
+      whatsNewInfo &&
+      !whatsNewInfo.disableOnUpdate &&
+      (!whatsNewInfo.version || whatsNewInfo.version !== __VERSION__)
     ) {
       dispatch(setWhatsNewModal(true));
     }
-  }, [systemInfo]);
+  }, [whatsNewInfo]);
   useOnDebugLogging();
   useOnNewAssets(); // handle new assets added
   useNotifications(); // handle notifications

--- a/src/extension/features/system/enums/ThunkEnum.ts
+++ b/src/extension/features/system/enums/ThunkEnum.ts
@@ -1,5 +1,6 @@
 enum ThunkEnum {
   FetchFromStorage = 'system/fetchFromStorage',
+  SaveDisableWhatsNewOnUpdate = 'system/saveDisableWhatsNewOnUpdate',
   SaveWhatsNewVersion = 'system/saveWhatsNewVersion',
   StartPollingForNetworkConnectivity = 'networks/startPollingForNetworkConnectivity',
   StopPollingForNetworkConnectivity = 'networks/stopPollingForNetworkConnectivity',

--- a/src/extension/features/system/slice.ts
+++ b/src/extension/features/system/slice.ts
@@ -6,6 +6,7 @@ import { StoreNameEnum } from '@extension/enums';
 // thunks
 import {
   fetchFromStorageThunk,
+  saveDisableWhatsNewOnUpdateThunk,
   saveWhatsNewVersionThunk,
   startPollingForNetworkConnectivityThunk,
   stopPollingForTransactionsParamsThunk,
@@ -29,6 +30,21 @@ const slice = createSlice({
         state.info = action.payload;
       }
     );
+    /** save disable what's on update **/
+    builder.addCase(
+      saveDisableWhatsNewOnUpdateThunk.fulfilled,
+      (state: IState, action: PayloadAction<boolean>) => {
+        if (state.info) {
+          state.info = {
+            ...state.info,
+            whatsNewInfo: {
+              ...state.info.whatsNewInfo,
+              disableOnUpdate: action.payload,
+            },
+          };
+        }
+      }
+    );
     /** save what's new version **/
     builder.addCase(
       saveWhatsNewVersionThunk.fulfilled,
@@ -36,7 +52,10 @@ const slice = createSlice({
         if (state.info) {
           state.info = {
             ...state.info,
-            whatsNewVersion: action.payload,
+            whatsNewInfo: {
+              ...state.info.whatsNewInfo,
+              version: action.payload,
+            },
           };
         }
       }

--- a/src/extension/features/system/thunks/index.ts
+++ b/src/extension/features/system/thunks/index.ts
@@ -1,4 +1,5 @@
 export { default as fetchFromStorageThunk } from './fetchFromStorageThunk';
+export { default as saveDisableWhatsNewOnUpdateThunk } from './saveDisableWhatsNewOnUpdateThunk';
 export { default as saveWhatsNewVersionThunk } from './saveWhatsNewVersionThunk';
 export { default as startPollingForNetworkConnectivityThunk } from './startPollingForNetworkConnectivityThunk';
 export { default as stopPollingForTransactionsParamsThunk } from './stopPollingForTransactionsParamsThunk';

--- a/src/extension/features/system/thunks/saveDisableWhatsNewOnUpdateThunk.ts
+++ b/src/extension/features/system/thunks/saveDisableWhatsNewOnUpdateThunk.ts
@@ -10,17 +10,13 @@ import SystemService from '@extension/services/SystemService';
 import type { IBaseAsyncThunkConfig, IMainRootState } from '@extension/types';
 import { MalformedDataError } from '@extension/errors';
 
-const saveWhatsNewVersionThunk: AsyncThunk<
-  string | null, // return
-  string | null, // args
+const saveDisableWhatsNewOnUpdateThunk: AsyncThunk<
+  boolean, // return
+  boolean, // args
   IBaseAsyncThunkConfig<IMainRootState>
-> = createAsyncThunk<
-  string | null,
-  string | null,
-  IBaseAsyncThunkConfig<IMainRootState>
->(
-  ThunkEnum.SaveWhatsNewVersion,
-  async (version, { getState, rejectWithValue }) => {
+> = createAsyncThunk<boolean, boolean, IBaseAsyncThunkConfig<IMainRootState>>(
+  ThunkEnum.SaveDisableWhatsNewOnUpdate,
+  async (value, { getState, rejectWithValue }) => {
     const logger = getState().system.logger;
     const systemInfo = getState().system.info;
     let _error: string;
@@ -28,7 +24,7 @@ const saveWhatsNewVersionThunk: AsyncThunk<
     if (!systemInfo) {
       _error = 'system info not found';
 
-      logger.debug(`${ThunkEnum.SaveWhatsNewVersion}: ${_error}`);
+      logger.debug(`${ThunkEnum.SaveDisableWhatsNewOnUpdate}: ${_error}`);
 
       return rejectWithValue(new MalformedDataError(_error));
     }
@@ -39,12 +35,12 @@ const saveWhatsNewVersionThunk: AsyncThunk<
       ...systemInfo,
       whatsNewInfo: {
         ...systemInfo.whatsNewInfo,
-        version,
+        disableOnUpdate: value,
       },
     });
 
-    return whatsNewInfo.version;
+    return whatsNewInfo.disableOnUpdate;
   }
 );
 
-export default saveWhatsNewVersionThunk;
+export default saveDisableWhatsNewOnUpdateThunk;

--- a/src/extension/modals/WhatsNewModal/WhatsNewModal.tsx
+++ b/src/extension/modals/WhatsNewModal/WhatsNewModal.tsx
@@ -24,8 +24,10 @@ import Link from '@extension/components/Link';
 import { BODY_BACKGROUND_COLOR, DEFAULT_GAP } from '@extension/constants';
 
 // features
-import { saveToStorageThunk as saveSettingsToStorageThunk } from '@extension/features/settings';
-import { saveWhatsNewVersionThunk } from '@extension/features/system';
+import {
+  saveDisableWhatsNewOnUpdateThunk,
+  saveWhatsNewVersionThunk,
+} from '@extension/features/system';
 
 // hooks
 import useDefaultTextColor from '@extension/hooks/useDefaultTextColor';
@@ -35,8 +37,8 @@ import useSubTextColor from '@extension/hooks/useSubTextColor';
 
 // selectors
 import {
-  useSelectSettings,
   useSelectWhatsNewModal,
+  useSelectSystemWhatsNewInfo,
 } from '@extension/selectors';
 
 // theme
@@ -54,8 +56,8 @@ const WhatsNewModal: FC<IModalProps> = ({ onClose }) => {
   const dispatch = useDispatch<IAppThunkDispatch<IMainRootState>>();
   const initialRef = createRef<HTMLButtonElement>();
   // selectors
-  const settings = useSelectSettings();
   const whatsNewModalOpen = useSelectWhatsNewModal();
+  const whatsNewInfo = useSelectSystemWhatsNewInfo();
   // hooks
   const defaultTextColor = useDefaultTextColor();
   const primaryColor = usePrimaryColor();
@@ -70,16 +72,13 @@ const WhatsNewModal: FC<IModalProps> = ({ onClose }) => {
   };
   const handleOnDisableOnUpdateChange = (
     event: ChangeEvent<HTMLInputElement>
-  ) =>
-    dispatch(
-      saveSettingsToStorageThunk({
-        ...settings,
-        general: {
-          ...settings.general,
-          disableWhatsNewModalOnUpdate: event.target.checked,
-        },
-      })
-    );
+  ) => {
+    if (!whatsNewInfo) {
+      return;
+    }
+
+    dispatch(saveDisableWhatsNewOnUpdateThunk(!whatsNewInfo.disableOnUpdate));
+  };
 
   return (
     <Modal
@@ -168,7 +167,7 @@ const WhatsNewModal: FC<IModalProps> = ({ onClose }) => {
               textAlign="left"
               w="full"
             >
-              With the Voi's MainNet rollout, there is a new incentive for early
+              With Voi's MainNet rollout, there is a new incentive for early
               participation: the <strong>Staking Program</strong>.
             </Text>
 
@@ -373,20 +372,22 @@ const WhatsNewModal: FC<IModalProps> = ({ onClose }) => {
 
         <ModalFooter p={DEFAULT_GAP}>
           <VStack alignItems="flex-start" spacing={DEFAULT_GAP - 2} w="full">
-            <Checkbox
-              colorScheme={primaryColorScheme}
-              isChecked={settings.general.disableWhatsNewModalOnUpdate}
-              onChange={handleOnDisableOnUpdateChange}
-            >
-              <Text
-                color={subTextColor}
-                fontSize="xs"
-                textAlign="left"
-                w="full"
+            {whatsNewInfo && (
+              <Checkbox
+                colorScheme={primaryColorScheme}
+                isChecked={whatsNewInfo.disableOnUpdate}
+                onChange={handleOnDisableOnUpdateChange}
               >
-                {t<string>('captions.disableWhatsNewMessageOnUpdate')}
-              </Text>
-            </Checkbox>
+                <Text
+                  color={subTextColor}
+                  fontSize="xs"
+                  textAlign="left"
+                  w="full"
+                >
+                  {t<string>('captions.disableWhatsNewMessageOnUpdate')}
+                </Text>
+              </Checkbox>
+            )}
 
             {/*ok*/}
             <Button

--- a/src/extension/modals/WhatsNewModal/WhatsNewModal.tsx
+++ b/src/extension/modals/WhatsNewModal/WhatsNewModal.tsx
@@ -98,7 +98,7 @@ const WhatsNewModal: FC<IModalProps> = ({ onClose }) => {
       >
         <ModalHeader justifyContent="center" px={DEFAULT_GAP}>
           <Heading color={defaultTextColor} fontSize="lg" textAlign="center">
-            {`What's New In Kibisis v2.0.0`}
+            {`What's New In Kibisis v${__VERSION__}`}
           </Heading>
         </ModalHeader>
 
@@ -137,7 +137,7 @@ const WhatsNewModal: FC<IModalProps> = ({ onClose }) => {
               >
                 12th September 2024
               </Link>{' '}
-              which means Voi has officially launched on MainNet!
+              which means Voi has officially launched its MainNet!
             </Text>
 
             <Text
@@ -146,10 +146,10 @@ const WhatsNewModal: FC<IModalProps> = ({ onClose }) => {
               textAlign="left"
               w="full"
             >
-              This truly has been a community effort, from the builders, the
+              This truly has been a community effort; from the builders, the
               node runners to the questers. Voi's TestNet has been a monumental
               success and Voi has a solid foundation that makes it an ecosystem
-              that is run by you, the Voiagers.
+              that is run by you: the Voiagers.
             </Text>
 
             <Heading
@@ -158,7 +158,7 @@ const WhatsNewModal: FC<IModalProps> = ({ onClose }) => {
               textAlign="left"
               w="full"
             >
-              MainNet Rollout: Staking Program
+              Voi MainNet Rollout: Staking Program
             </Heading>
 
             <Text

--- a/src/extension/pages/GeneralSettingsPage/GeneralSettingsPage.tsx
+++ b/src/extension/pages/GeneralSettingsPage/GeneralSettingsPage.tsx
@@ -140,18 +140,6 @@ const GeneralSettingsPage: FC = () => {
 
       {/*content*/}
       <VStack spacing={DEFAULT_GAP - 2} w="full">
-        {/*start-up*/}
-        <VStack w="full">
-          <SettingsSubHeading text={t<string>('headings.startUp')} />
-
-          <SettingsSwitchItem
-            checked={settings.general.disableWhatsNewModalOnUpdate}
-            description={t<string>('captions.disableWhatsNewModalOnUpdate')}
-            label={t<string>('labels.disableWhatsNewModalOnUpdate')}
-            onChange={handleOnSwitchChange('disableWhatsNewModalOnUpdate')}
-          />
-        </VStack>
-
         {/* network */}
         <VStack w="full">
           <SettingsSubHeading text={t<string>('headings.network')} />

--- a/src/extension/selectors/system/index.ts
+++ b/src/extension/selectors/system/index.ts
@@ -1,3 +1,4 @@
 export { default as useSelectIsOnline } from './useSelectIsOnline';
 export { default as useSelectLogger } from './useSelectLogger';
 export { default as useSelectSystemInfo } from './useSelectSystemInfo';
+export { default as useSelectSystemWhatsNewInfo } from './useSelectSystemWhatsNewInfo';

--- a/src/extension/selectors/system/useSelectSystemWhatsNewInfo.ts
+++ b/src/extension/selectors/system/useSelectSystemWhatsNewInfo.ts
@@ -1,0 +1,10 @@
+import { useSelector } from 'react-redux';
+
+// types
+import type { IBaseRootState, IWhatsNewInfo } from '@extension/types';
+
+export default function useSelectSystemWhatsNewInfo(): IWhatsNewInfo | null {
+  return useSelector<IBaseRootState, IWhatsNewInfo | null>(
+    (state) => state.system.info?.whatsNewInfo || null
+  );
+}

--- a/src/extension/services/SettingsService/SettingsService.ts
+++ b/src/extension/services/SettingsService/SettingsService.ts
@@ -47,7 +47,6 @@ export default class SettingsService extends BaseService {
         theme: 'light',
       },
       general: {
-        disableWhatsNewModalOnUpdate: false,
         preferredBlockExplorerIds: {},
         preferredNFTExplorerIds: {},
         selectedNetworkGenesisHash: genesisHash,
@@ -92,7 +91,6 @@ export default class SettingsService extends BaseService {
         theme: appearance.theme,
       },
       general: {
-        disableWhatsNewModalOnUpdate: general.disableWhatsNewModalOnUpdate,
         preferredBlockExplorerIds: general.preferredBlockExplorerIds,
         preferredNFTExplorerIds: general.preferredNFTExplorerIds,
         selectedNetworkGenesisHash: general.selectedNetworkGenesisHash,

--- a/src/extension/services/SystemService/SystemService.ts
+++ b/src/extension/services/SystemService/SystemService.ts
@@ -18,7 +18,10 @@ export default class SystemService extends BaseService {
   public static initializeDefaultSystem(): ISystemInfo {
     return {
       deviceID: uuid(),
-      whatsNewVersion: null,
+      whatsNewInfo: {
+        disableOnUpdate: false,
+        version: null,
+      },
     };
   }
 
@@ -29,7 +32,7 @@ export default class SystemService extends BaseService {
   private _sanitize(item: ISystemInfo): ISystemInfo {
     return {
       deviceID: item.deviceID || null,
-      whatsNewVersion: item.whatsNewVersion || null,
+      whatsNewInfo: item.whatsNewInfo,
     };
   }
 

--- a/src/extension/translations/en.ts
+++ b/src/extension/translations/en.ts
@@ -119,7 +119,6 @@ const translation: IResourceLanguage = {
     defaultConfirm: 'Are you sure?',
     deleteApplication: 'Be careful, deleting an application is irreversible!',
     destroyAsset: 'Be careful, destroying an asset is irreversible!',
-    disableWhatsNewModalOnUpdate: `Whether to disable the "What's New" update message.`,
     disableWhatsNewMessageOnUpdate: `Disable message on update?`,
     disconnectAllSessions: 'Are you sure you want to disconnect all sessions?',
     displayingCountOfTotal: 'Displaying {{count}} of {{total}}',
@@ -416,7 +415,6 @@ const translation: IResourceLanguage = {
     shareAddress: 'Share Address',
     screenCaptureDenied: 'Screen Capture Denied',
     screenCaptureLoading: 'Screen Capture Loading',
-    startUp: 'Start-up',
     transaction: 'Unknown Transaction 💀',
     [`transaction_${TransactionTypeEnum.AccountReKey}`]: 'Re-Key Account 🔒',
     [`transaction_${TransactionTypeEnum.AccountUndoReKey}`]:
@@ -528,7 +526,6 @@ const translation: IResourceLanguage = {
     deviceID: 'Device ID',
     did: 'DID',
     disabled: 'Disabled',
-    disableWhatsNewModalOnUpdate: `Disable "What's New" Message?`,
     disconnect: 'Disconnect',
     editAccount: 'Edit Account',
     enableCredentialsLock: 'Enable Credential Lock?',

--- a/src/extension/types/settings/IGeneralSettings.ts
+++ b/src/extension/types/settings/IGeneralSettings.ts
@@ -1,12 +1,10 @@
 /**
- * @property {boolean} disableWhatsNewModalOnUpdate - whether the What's New modal is disabled after each update.
  * @property {Record<string, string | null>} preferredBlockExplorerIds - the preferred block explorer for each network.
  * @property {Record<string, string | null>} preferredNFTExplorerIds - the preferred NFT explorers for each network.
  * @property {string | null} selectedNetworkGenesisHash - the selected network genesis hash.
  * @property {Record<string, string | null>} selectedNodeIDs - the selected node IDs for each network.
  */
 interface IGeneralSettings {
-  disableWhatsNewModalOnUpdate: boolean;
   preferredBlockExplorerIds: Record<string, string | null>;
   preferredNFTExplorerIds: Record<string, string | null>;
   selectedNetworkGenesisHash: string | null;

--- a/src/extension/types/system/ISystemInfo.ts
+++ b/src/extension/types/system/ISystemInfo.ts
@@ -1,6 +1,9 @@
+// types
+import type IWhatsNewInfo from './IWhatsNewInfo';
+
 interface ISystemInfo {
   deviceID: string | null;
-  whatsNewVersion: string | null;
+  whatsNewInfo: IWhatsNewInfo;
 }
 
 export default ISystemInfo;

--- a/src/extension/types/system/IWhatsNewInfo.ts
+++ b/src/extension/types/system/IWhatsNewInfo.ts
@@ -1,0 +1,6 @@
+interface IWhatsNewInfo {
+  disableOnUpdate: boolean;
+  version: string | null;
+}
+
+export default IWhatsNewInfo;

--- a/src/extension/types/system/index.ts
+++ b/src/extension/types/system/index.ts
@@ -1,2 +1,3 @@
 export type { default as INetworkConnectivity } from './INetworkConnectivity';
 export type { default as ISystemInfo } from './ISystemInfo';
+export type { default as IWhatsNewInfo } from './IWhatsNewInfo';


### PR DESCRIPTION
<!--
The title should summarise what the purpose of this change,

⚠️**NOTE:** The title must conform to the conventional commit message format outlined in CONTRIBUTING.md document, at the root of the project. This is to ensure the merge commit to the main branch is picked up by the CI and creates an entry in the CHANGELOG.md.
-->

# Description
<!-- Describe your changes in detail -->
* Move the setting to disable the "What's New" modal to object in the system info.
  - System info uses a `whatsNewInfo` object with the disable on update setting and the version.
* Remove `disableWhatsNewOnUpdate` setting from settings.
* Fix typos in "What's New" modal.

# Type of change
<!-- What type of change does this change introduce? Put an 'x' in all the boxes that apply. -->

- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🏗️ Build configuration (CI configuration, scaffolding etc.)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 📝 Documentation update(s)
- [ ] 📦 Dependency update(s)
- [ ] 👩🏽‍💻 Improve developer experience
- [ ] ⚡ Improve performance
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] ♻ Refactor
- [ ] ⏪ Revert changes
- [ ] 🧪 New tests or updates to existing tests