### PR TITLE
fix: use fixed integers in atomic unit bignumber conversions 

### DIFF
--- a/src/extension/contracts/ARC0072Contract/ARC0072Contract.ts
+++ b/src/extension/contracts/ARC0072Contract/ARC0072Contract.ts
@@ -58,10 +58,8 @@ export default class ARC0072Contract extends BaseContract {
       // if the first arg, owner, is not an address
       if (!abiAddressArgType || abiAddressArgType.toString() !== 'address') {
         throw new InvalidABIContractError(
-          this._appId.toString(),
-          `application "${this._appId.toString()}" not valid as method "${
-            ARC0072MethodEnum.BalanceOf
-          }" has an invalid "owner" type`
+          this._appId,
+          `application "${this._appId}" not valid as method "${ARC0072MethodEnum.BalanceOf}" has an invalid "owner" type`
         );
       }
 
@@ -79,8 +77,8 @@ export default class ARC0072Contract extends BaseContract {
 
     if (!result) {
       throw new InvalidABIContractError(
-        this._appId.toString(),
-        `application "${this._appId.toString()}" not valid because the result returned "null"`
+        this._appId,
+        `application "${this._appId}" not valid because the result returned "null"`
       );
     }
 
@@ -120,8 +118,8 @@ export default class ARC0072Contract extends BaseContract {
 
     if (!result) {
       throw new InvalidABIContractError(
-        this._appId.toString(),
-        `application "${this._appId.toString()}" not valid because the result returned "null"`
+        this._appId,
+        `application "${this._appId}" not valid because the result returned "null"`
       );
     }
 
@@ -165,8 +163,8 @@ export default class ARC0072Contract extends BaseContract {
 
     if (!result) {
       throw new InvalidABIContractError(
-        this._appId.toString(),
-        `application "${this._appId.toString()}" not valid because the result returned "null"`
+        this._appId,
+        `application "${this._appId}" not valid because the result returned "null"`
       );
     }
 
@@ -205,8 +203,8 @@ export default class ARC0072Contract extends BaseContract {
 
     if (!result) {
       throw new InvalidABIContractError(
-        this._appId.toString(),
-        `application "${this._appId.toString()}" not valid because the result returned "null"`
+        this._appId,
+        `application "${this._appId}" not valid because the result returned "null"`
       );
     }
 
@@ -239,8 +237,8 @@ export default class ARC0072Contract extends BaseContract {
 
     if (!result) {
       throw new InvalidABIContractError(
-        this._appId.toString(),
-        `application "${this._appId.toString()}" not valid because the result returned "null"`
+        this._appId,
+        `application "${this._appId}" not valid because the result returned "null"`
       );
     }
 

--- a/src/extension/contracts/ARC0072Contract/ARC0072Contract.ts
+++ b/src/extension/contracts/ARC0072Contract/ARC0072Contract.ts
@@ -104,7 +104,7 @@ export default class ARC0072Contract extends BaseContract {
     try {
       abiMethod = this._abi.getMethodByName(ARC0072MethodEnum.OwnerOf);
       encodedTokenId = (abiMethod.args[0].type as ABIType).encode(
-        BigInt(tokenId.toString())
+        BigInt(tokenId.toFixed())
       );
       result = (await this.readByMethod({
         abiMethod,
@@ -149,7 +149,7 @@ export default class ARC0072Contract extends BaseContract {
     try {
       abiMethod = this._abi.getMethodByName(ARC0072MethodEnum.TokenByIndex);
       encodedIndex = (abiMethod.args[0].type as ABIType).encode(
-        BigInt(index.toString())
+        BigInt(index.toFixed())
       );
       result = (await this.readByMethod({
         abiMethod,
@@ -189,7 +189,7 @@ export default class ARC0072Contract extends BaseContract {
     try {
       abiMethod = this._abi.getMethodByName(ARC0072MethodEnum.TokenURI);
       encodedTokenId = (abiMethod.args[0].type as ABIType).encode(
-        BigInt(tokenId.toString())
+        BigInt(tokenId.toFixed())
       );
       result = (await this.readByMethod({
         abiMethod,

--- a/src/extension/contracts/ARC0200Contract/ARC0200Contract.test.ts
+++ b/src/extension/contracts/ARC0200Contract/ARC0200Contract.test.ts
@@ -91,10 +91,10 @@ describe.skip(`${__dirname}#ARC0200Contract`, () => {
       const result: IARC0200AssetInformation = await contract.metadata();
 
       // assert
-      expect(result.decimals).toBe(BigInt(String(decimals.toString())));
+      expect(result.decimals).toBe(BigInt(decimals.toFixed()));
       expect(result.name).toBe(name);
       expect(result.symbol).toBe(symbol);
-      expect(result.totalSupply).toBe(BigInt(String(totalSupply.toString())));
+      expect(result.totalSupply).toBe(BigInt(totalSupply.toFixed()));
     });
   });
 

--- a/src/extension/contracts/ARC0200Contract/ARC0200Contract.ts
+++ b/src/extension/contracts/ARC0200Contract/ARC0200Contract.ts
@@ -75,10 +75,8 @@ export default class ARC0200Contract extends BaseContract {
       // if the first arg, owner, is not an address
       if (!abiAddressArgType || abiAddressArgType.toString() !== 'address') {
         throw new InvalidABIContractError(
-          this._appId.toString(),
-          `application "${this._appId.toString()}" not valid as method "${
-            ARC0200MethodEnum.BalanceOf
-          }" has an invalid "owner" type`
+          this._appId,
+          `application "${this._appId}" not valid as method "${ARC0200MethodEnum.BalanceOf}" has an invalid "owner" type`
         );
       }
 
@@ -96,8 +94,8 @@ export default class ARC0200Contract extends BaseContract {
 
     if (!result) {
       throw new InvalidABIContractError(
-        this._appId.toString(),
-        `application "${this._appId.toString()}" not valid because the result returned "null"`
+        this._appId,
+        `application "${this._appId}" not valid because the result returned "null"`
       );
     }
 
@@ -133,10 +131,8 @@ export default class ARC0200Contract extends BaseContract {
         abiMethod.args[0].type.toString() !== 'address'
       ) {
         throw new InvalidABIContractError(
-          this._appId.toString(),
-          `application "${this._appId.toString()}" not valid as method "${
-            ARC0200MethodEnum.Transfer
-          }" has an invalid "to" type`
+          this._appId,
+          `application "${this._appId}" not valid as method "${ARC0200MethodEnum.Transfer}" has an invalid "to" type`
         );
       }
 
@@ -146,15 +142,13 @@ export default class ARC0200Contract extends BaseContract {
         abiMethod.args[1].type.toString() !== 'uint256'
       ) {
         throw new InvalidABIContractError(
-          this._appId.toString(),
-          `application "${this._appId.toString()}" not valid as method "${
-            ARC0200MethodEnum.Transfer
-          }" has an invalid "value" type`
+          this._appId,
+          `application "${this._appId}" not valid as method "${ARC0200MethodEnum.Transfer}" has an invalid "value" type`
         );
       }
 
       encodedAmount = (abiMethod.args[1].type as ABIType).encode(
-        BigInt(String(amountInAtomicUnits.toString()))
+        BigInt(amountInAtomicUnits.toFixed())
       );
       encodedToAddress = (abiMethod.args[0].type as ABIType).encode(toAddress);
       appArgs = [encodedToAddress, encodedAmount];
@@ -187,10 +181,10 @@ export default class ARC0200Contract extends BaseContract {
         paymentTransaction = makePaymentTxnWithSuggestedParams(
           fromAddress,
           this.applicationAddress(), // send funds to application account
-          BigInt(String(boxStorageAmount.toString())),
+          BigInt(boxStorageAmount.toFixed()),
           undefined,
           new TextEncoder().encode(
-            `initial box storage funding for account "${toAddress}" in application "${this._appId.toString()}"`
+            `initial box storage funding for account "${toAddress}" in application "${this._appId}"`
           ),
           suggestedParams
         );
@@ -254,8 +248,8 @@ export default class ARC0200Contract extends BaseContract {
 
     if (!result) {
       throw new InvalidABIContractError(
-        this._appId.toString(),
-        `application "${this._appId.toString()}" not valid because the result returned "null"`
+        this._appId,
+        `application "${this._appId}" not valid because the result returned "null"`
       );
     }
 
@@ -301,7 +295,7 @@ export default class ARC0200Contract extends BaseContract {
 
       if (response.txnGroups[0].failureMessage) {
         throw new ReadABIContractError(
-          this._appId.toString(),
+          this._appId,
           response.txnGroups[0].failureMessage
         );
       }
@@ -323,8 +317,8 @@ export default class ARC0200Contract extends BaseContract {
     // if any are null, the application is not a valid arc-0200 application
     if (results.some((value) => !value)) {
       throw new InvalidABIContractError(
-        this._appId.toString(),
-        `application "${this._appId.toString()}" not valid because a result returned "null"`
+        this._appId,
+        `application "${this._appId}" not valid because a result returned "null"`
       );
     }
 
@@ -365,8 +359,8 @@ export default class ARC0200Contract extends BaseContract {
 
     if (!result) {
       throw new InvalidABIContractError(
-        this._appId.toString(),
-        `application "${this._appId.toString()}" not valid because the result returned "null"`
+        this._appId,
+        `application "${this._appId}" not valid because the result returned "null"`
       );
     }
 
@@ -399,8 +393,8 @@ export default class ARC0200Contract extends BaseContract {
 
     if (!result) {
       throw new InvalidABIContractError(
-        this._appId.toString(),
-        `application "${this._appId.toString()}" not valid because the result returned "null"`
+        this._appId,
+        `application "${this._appId}" not valid because the result returned "null"`
       );
     }
 
@@ -433,8 +427,8 @@ export default class ARC0200Contract extends BaseContract {
 
     if (!result) {
       throw new InvalidABIContractError(
-        this._appId.toString(),
-        `application "${this._appId.toString()}" not valid because the result returned "null"`
+        this._appId,
+        `application "${this._appId}" not valid because the result returned "null"`
       );
     }
 

--- a/src/extension/contracts/ARC0200Contract/ARC0200Contract.ts
+++ b/src/extension/contracts/ARC0200Contract/ARC0200Contract.ts
@@ -329,7 +329,7 @@ export default class ARC0200Contract extends BaseContract {
       decimals: (decimalResult as BigNumber).toNumber(),
       name: this.trimNullBytes(nameResult as string),
       symbol: this.trimNullBytes(symbolResult as string),
-      totalSupply: (totalSupplyResult as BigNumber).toString(),
+      totalSupply: (totalSupplyResult as BigNumber).toFixed(),
     };
   }
 

--- a/src/extension/contracts/BaseContract/BaseContract.ts
+++ b/src/extension/contracts/BaseContract/BaseContract.ts
@@ -202,11 +202,7 @@ export default class BaseContract {
 
     if (!log) {
       this._logger.debug(
-        `${
-          BaseContract.name
-        }#${_functionName}: no log found for application "${this._appId.toString()}" and method "${
-          abiMethod.name
-        }"`
+        `${BaseContract.name}#${_functionName}: no log found for application "${this._appId}" and method "${abiMethod.name}"`
       );
 
       return null;
@@ -246,7 +242,7 @@ export default class BaseContract {
     appArgs,
     suggestedParams,
   }: IBaseApplicationOptions): Promise<IABIResult | null> {
-    const _functionName: string = 'readByMethod';
+    const _functionName = 'readByMethod';
     let response: algosdk.modelsv2.SimulateResponse;
     let transaction: Transaction;
 
@@ -265,7 +261,7 @@ export default class BaseContract {
 
       if (response.txnGroups[0].failureMessage) {
         throw new ReadABIContractError(
-          this._appId.toString(),
+          this._appId,
           response.txnGroups[0].failureMessage
         );
       }
@@ -293,9 +289,7 @@ export default class BaseContract {
   protected async simulateTransactions(
     simulateTransactions: ISimulateTransaction[]
   ): Promise<algosdk.modelsv2.SimulateResponse> {
-    const transactions: Transaction[] = simulateTransactions.map(
-      (value) => value.transaction
-    );
+    const transactions = simulateTransactions.map((value) => value.transaction);
     let request: algosdk.modelsv2.SimulateRequest;
 
     assignGroupID(transactions);
@@ -346,7 +340,7 @@ export default class BaseContract {
    * @returns {string} the base32 encoded address for the application.
    */
   public applicationAddress(): string {
-    return getApplicationAddress(BigInt(this._appId.toString()));
+    return getApplicationAddress(BigInt(this._appId));
   }
 
   /**
@@ -362,7 +356,7 @@ export default class BaseContract {
   public async boxByName(
     name: Uint8Array
   ): Promise<algosdk.modelsv2.Box | null> {
-    const _functionName: string = 'boxByName';
+    const _functionName = 'boxByName';
 
     try {
       return await this._algod

--- a/src/extension/features/send-assets/thunks/createUnsignedTransactionsThunk.ts
+++ b/src/extension/features/send-assets/thunks/createUnsignedTransactionsThunk.ts
@@ -121,7 +121,7 @@ const createUnsignedTransactionsThunk: AsyncThunk<
       amountInAtomicUnits = convertToAtomicUnit(
         new BigNumber(amountInStandardUnits),
         asset.decimals
-      ).toString(); // convert to atomic units
+      ).toFixed(); // convert to atomic units
 
       switch (asset.type) {
         case AssetTypeEnum.ARC0200:

--- a/src/extension/hooks/useAmountInput/useAmountInput.ts
+++ b/src/extension/hooks/useAmountInput/useAmountInput.ts
@@ -35,7 +35,7 @@ export default function useAmountInput({ label, required }: IOptions): IState {
 
       // if the entered value is greater than the maximum allowed, use the max
       if (_value.gt(maximumAmountInStandardUnits)) {
-        setValue(_value.toString());
+        setValue(_value.toFixed());
 
         return;
       }

--- a/src/extension/modals/SendAssetModal/SendAssetModal.tsx
+++ b/src/extension/modals/SendAssetModal/SendAssetModal.tsx
@@ -552,11 +552,11 @@ const SendAssetModal: FC<IModalProps> = ({ onClose }) => {
       network,
     });
 
-    setMaximumAmountInAtomicUnits(_maximumAmountInAtomicUnits.toString());
+    setMaximumAmountInAtomicUnits(_maximumAmountInAtomicUnits.toFixed());
 
     // if the amount exceeds the new maximum transaction amount, set the amount to the maximum transaction amount
     if (new BigNumber(amountValue).gt(_maximumAmountInAtomicUnits)) {
-      setAmountValue(_maximumAmountInAtomicUnits.toString());
+      setAmountValue(_maximumAmountInAtomicUnits.toFixed());
 
       return;
     }

--- a/src/extension/modals/WhatsNewModal/WhatsNewModal.tsx
+++ b/src/extension/modals/WhatsNewModal/WhatsNewModal.tsx
@@ -64,8 +64,10 @@ const WhatsNewModal: FC<IModalProps> = ({ onClose }) => {
   const primaryColorScheme = usePrimaryColorScheme();
   const subTextColor = useSubTextColor();
   // misc
-  const features = ['🖼️ Add Voi mainnet indexers and explorer.'];
-  const fixes: string[] = [];
+  const features: string[] = [];
+  const fixes: string[] = [
+    'Assets with large decimals can successfully transferred.',
+  ];
   // handlers
   const handleClose = () => {
     // mark as read

--- a/src/extension/modals/WhatsNewModal/WhatsNewModal.tsx
+++ b/src/extension/modals/WhatsNewModal/WhatsNewModal.tsx
@@ -66,7 +66,7 @@ const WhatsNewModal: FC<IModalProps> = ({ onClose }) => {
   // misc
   const features: string[] = [];
   const fixes: string[] = [
-    'Assets with large decimals can successfully transferred.',
+    'Assets with large decimals can successfully be transferred.',
   ];
   // handlers
   const handleClose = () => {

--- a/src/extension/models/NetworkClient/NetworkClient.ts
+++ b/src/extension/models/NetworkClient/NetworkClient.ts
@@ -213,7 +213,7 @@ export default class NetworkClient {
           totalSupply = await contract.totalSupply();
 
           return {
-            totalSupply: BigInt(totalSupply.toString()),
+            totalSupply: BigInt(totalSupply.toFixed()),
           };
         } catch (error) {
           switch (error.code) {

--- a/src/extension/models/NetworkClient/NetworkClient.ts
+++ b/src/extension/models/NetworkClient/NetworkClient.ts
@@ -179,7 +179,7 @@ export default class NetworkClient {
 
         return {
           id: assetID,
-          amount: result.toString(),
+          amount: result.toFixed(),
           type: AssetTypeEnum.ARC0200,
         };
       },

--- a/src/extension/utils/calculateMinimumBalanceRequirementForStandardAssets/calculateMinimumBalanceRequirementForStandardAssets.test.ts
+++ b/src/extension/utils/calculateMinimumBalanceRequirementForStandardAssets/calculateMinimumBalanceRequirementForStandardAssets.test.ts
@@ -91,7 +91,7 @@ describe(`${__dirname}/calculateMinimumBalanceRequirementForStandardAssets`, () 
     }: ITestParams) => {
       account.networkInformation[encodedGenesisHash] = {
         ...account.networkInformation[encodedGenesisHash],
-        minAtomicBalance: minBalanceInAtomicUnits.toString(),
+        minAtomicBalance: minBalanceInAtomicUnits.toFixed(),
       };
 
       expect(

--- a/src/extension/utils/mapARC0072AssetFromARC0072AssetInformation/mapARC0072AssetFromARC0072AssetInformation.ts
+++ b/src/extension/utils/mapARC0072AssetFromARC0072AssetInformation/mapARC0072AssetFromARC0072AssetInformation.ts
@@ -15,7 +15,7 @@ export default function mapARC0072AssetFromARC0072AssetInformation(
     id: appId,
     totalSupply: new BigNumber(
       String(assetInformation.totalSupply as bigint)
-    ).toString(),
+    ).toFixed(),
     type: AssetTypeEnum.ARC0072,
     verified,
   };

--- a/src/extension/utils/mapAVMAccountInformationToAccount/mapAVMAccountInformationToAccount.ts
+++ b/src/extension/utils/mapAVMAccountInformationToAccount/mapAVMAccountInformationToAccount.ts
@@ -18,13 +18,13 @@ export default function mapAVMAccountInformationToAccountInformation(
     ...accountInformation,
     atomicBalance: new BigNumber(
       String(avmAccountInformation.amount as bigint)
-    ).toString(),
+    ).toFixed(),
     authAddress: avmAccountInformation['auth-addr'] || null,
     minAtomicBalance: new BigNumber(
       String(avmAccountInformation['min-balance'] as bigint)
-    ).toString(),
+    ).toFixed(),
     standardAssetHoldings: avmAccountInformation.assets.map((value) => ({
-      amount: new BigNumber(String(value.amount as bigint)).toString(),
+      amount: new BigNumber(String(value.amount as bigint)).toFixed(),
       id: new BigNumber(String(value['asset-id'] as bigint)).toString(),
       isFrozen: value['is-frozen'],
       type: AssetTypeEnum.Standard,

--- a/src/extension/utils/mapAlgorandTransactionToTransaction/mapAlgorandTransactionToTransaction.ts
+++ b/src/extension/utils/mapAlgorandTransactionToTransaction/mapAlgorandTransactionToTransaction.ts
@@ -30,7 +30,7 @@ export default function mapAlgorandTransactionToTransaction(
           .multipliedBy(1000) // we want milliseconds, as 'round-time' is in seconds
           .toNumber()
       : null,
-    fee: new BigNumber(String(algorandTransaction.fee as bigint)).toString(),
+    fee: new BigNumber(String(algorandTransaction.fee as bigint)).toFixed(),
     id: algorandTransaction.id || null,
     genesisHash: algorandTransaction['genesis-hash'] || null,
     groupId: algorandTransaction.group || null,

--- a/src/extension/utils/mapAlgorandTransactionToTransaction/parseApplicationTransaction.ts
+++ b/src/extension/utils/mapAlgorandTransactionToTransaction/parseApplicationTransaction.ts
@@ -24,7 +24,7 @@ export default function parseApplicationTransaction(
     algorandApplicationTransaction['application-id'] > 0
       ? new BigNumber(
           String(algorandApplicationTransaction['application-id'] as bigint)
-        ).toString()
+        ).toFixed()
       : null;
   let type: IApplicationTransactionTypes = TransactionTypeEnum.ApplicationNoOp;
 
@@ -66,11 +66,11 @@ export default function parseApplicationTransaction(
       : null,
     foreignApps:
       algorandApplicationTransaction['foreign-apps']?.map((value) =>
-        new BigNumber(String(value as bigint)).toString()
+        new BigNumber(String(value as bigint)).toFixed()
       ) || null,
     foreignAssets:
       algorandApplicationTransaction['foreign-assets']?.map((value) =>
-        new BigNumber(String(value as bigint)).toString()
+        new BigNumber(String(value as bigint)).toFixed()
       ) || null,
     innerTransactions:
       innerTransactions?.map(mapAlgorandTransactionToTransaction) || null,

--- a/src/extension/utils/mapAlgorandTransactionToTransaction/parseAssetConfigTransaction.ts
+++ b/src/extension/utils/mapAlgorandTransactionToTransaction/parseAssetConfigTransaction.ts
@@ -35,7 +35,7 @@ export default function parseAssetConfigTransaction(
       reserve: algorandAssetConfigTransaction.params.reserve || null,
       total: new BigNumber(
         String(algorandAssetConfigTransaction.params.total as bigint)
-      ).toString(),
+      ).toFixed(),
       unitName: algorandAssetConfigTransaction.params['unit-name'] || null,
       url: algorandAssetConfigTransaction.params.url || null,
       type: TransactionTypeEnum.AssetCreate,
@@ -53,7 +53,7 @@ export default function parseAssetConfigTransaction(
       ...baseTransaction,
       assetId: new BigNumber(
         String(algorandAssetConfigTransaction['asset-id'] as bigint)
-      ).toString(),
+      ).toFixed(),
       clawback: algorandAssetConfigTransaction.params.clawback,
       creator: algorandAssetConfigTransaction.params.creator,
       decimals: Number(algorandAssetConfigTransaction.params.decimals),
@@ -63,7 +63,7 @@ export default function parseAssetConfigTransaction(
       reserve: algorandAssetConfigTransaction.params.reserve,
       total: new BigNumber(
         String(algorandAssetConfigTransaction.params.total as bigint)
-      ).toString(),
+      ).toFixed(),
       type: TransactionTypeEnum.AssetConfig,
     };
   }
@@ -72,13 +72,13 @@ export default function parseAssetConfigTransaction(
     ...baseTransaction,
     assetId: new BigNumber(
       String(algorandAssetConfigTransaction['asset-id'] as bigint)
-    ).toString(),
+    ).toFixed(),
     creator: algorandAssetConfigTransaction.params.creator,
     decimals: Number(algorandAssetConfigTransaction.params.decimals),
     defaultFrozen: algorandAssetConfigTransaction.params['default-frozen'],
     total: new BigNumber(
       String(algorandAssetConfigTransaction.params.total as bigint)
-    ).toString(),
+    ).toFixed(),
     type: TransactionTypeEnum.AssetDestroy,
   };
 }

--- a/src/extension/utils/mapAlgorandTransactionToTransaction/parseAssetFreezeTransaction.ts
+++ b/src/extension/utils/mapAlgorandTransactionToTransaction/parseAssetFreezeTransaction.ts
@@ -19,7 +19,7 @@ export default function parseAssetFreezeTransaction(
     ...baseTransaction,
     assetId: new BigNumber(
       String(algorandAssetFreezeTransaction['asset-id'] as bigint)
-    ).toString(),
+    ).toFixed(),
     frozenAddress: algorandAssetFreezeTransaction.address,
     type: algorandAssetFreezeTransaction['new-freeze-status']
       ? TransactionTypeEnum.AssetFreeze

--- a/src/extension/utils/mapAlgorandTransactionToTransaction/parseAssetTransferTransaction.ts
+++ b/src/extension/utils/mapAlgorandTransactionToTransaction/parseAssetTransferTransaction.ts
@@ -18,10 +18,10 @@ export default function parseAssetTransferTransaction(
     ...baseTransaction,
     amount: new BigNumber(
       String(algorandAssetTransferTransaction.amount as bigint)
-    ).toString(),
+    ).toFixed(),
     assetId: new BigNumber(
       String(algorandAssetTransferTransaction['asset-id'] as bigint)
-    ).toString(),
+    ).toFixed(),
     receiver: algorandAssetTransferTransaction.receiver,
     type: TransactionTypeEnum.AssetTransfer,
   };

--- a/src/extension/utils/mapAlgorandTransactionToTransaction/parseKeyRegistrationTransaction.ts
+++ b/src/extension/utils/mapAlgorandTransactionToTransaction/parseKeyRegistrationTransaction.ts
@@ -28,15 +28,15 @@ export default function parseAssetFreezeTransaction(
         algorandKeyRegistrationTransaction['selection-participation-key'],
       voteFirstValid: new BigNumber(
         String(algorandKeyRegistrationTransaction['vote-first-valid'] as bigint)
-      ).toString(),
+      ).toFixed(),
       voteKeyDilution: new BigNumber(
         String(
           algorandKeyRegistrationTransaction['vote-key-dilution'] as bigint
         )
-      ).toString(),
+      ).toFixed(),
       voteLastValid: new BigNumber(
         String(algorandKeyRegistrationTransaction['vote-last-valid'] as bigint)
-      ).toString(),
+      ).toFixed(),
       voteParticipationKey:
         algorandKeyRegistrationTransaction['vote-participation-key'],
       type: TransactionTypeEnum.KeyRegistrationOnline,

--- a/src/extension/utils/mapAlgorandTransactionToTransaction/parsePaymentAndReKeyTransaction.ts
+++ b/src/extension/utils/mapAlgorandTransactionToTransaction/parsePaymentAndReKeyTransaction.ts
@@ -34,7 +34,7 @@ export default function parsePaymentAndReKeyTransaction(
 
   return {
     ...baseTransaction,
-    amount: amount.toString(),
+    amount: amount.toFixed(),
     receiver: algorandPaymentTransaction.receiver,
     type,
   };

--- a/src/extension/utils/mapStandardAssetFromAlgorandAsset/mapStandardAssetFromAlgorandAsset.ts
+++ b/src/extension/utils/mapStandardAssetFromAlgorandAsset/mapStandardAssetFromAlgorandAsset.ts
@@ -21,7 +21,7 @@ export default function mapStandardAssetFromAlgorandAsset(
     deleted: algorandAsset.deleted || false,
     freezeAddress: algorandAsset.params.freeze || null,
     iconUrl,
-    id: new BigNumber(String(algorandAsset.index as bigint)).toString(),
+    id: new BigNumber(String(algorandAsset.index as bigint)).toFixed(),
     managerAddress: algorandAsset.params.manager || null,
     metadataHash: algorandAsset.params['metadata-hash'] || null,
     name: algorandAsset.params.name || null,
@@ -29,7 +29,7 @@ export default function mapStandardAssetFromAlgorandAsset(
     reserveAddress: algorandAsset.params.reserve || null,
     totalSupply: new BigNumber(
       String(algorandAsset.params.total as bigint)
-    ).toString(),
+    ).toFixed(),
     type: AssetTypeEnum.Standard,
     unitName: algorandAsset.params['unit-name'] || null,
     unitNameBase64: algorandAsset.params['unit-name-b64'] || null,

--- a/src/extension/utils/parseARC0200Transaction/parseARC0200Transaction.ts
+++ b/src/extension/utils/parseARC0200Transaction/parseARC0200Transaction.ts
@@ -53,7 +53,7 @@ export default function parseARC0200Transaction(
       amount: ARC0200Contract.formatBase64EncodedUintArg(
         transaction.applicationArgs[2],
         256
-      ).toString(),
+      ).toFixed(),
       receiver: ARC0200Contract.formatBase64EncodedAddressArg(
         transaction.applicationArgs[1]
       ),


### PR DESCRIPTION
<!--
The title should summarise what the purpose of this change,

⚠️**NOTE:** The title must conform to the conventional commit message format outlined in CONTRIBUTING.md document, at the root of the project. This is to ensure the merge commit to the main branch is picked up by the CI and creates an entry in the CHANGELOG.md.
-->

# Description
<!-- Describe your changes in detail -->
* For atomic unit conversions, use `BigNumber.toFixed()` to ensure the exponent form is not used such as when using `BigNumber.toString()`.

# Type of change
<!-- What type of change does this change introduce? Put an 'x' in all the boxes that apply. -->

- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🏗️ Build configuration (CI configuration, scaffolding etc.)
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 📝 Documentation update(s)
- [ ] 📦 Dependency update(s)
- [ ] 👩🏽‍💻 Improve developer experience
- [ ] ⚡ Improve performance
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] ♻ Refactor
- [ ] ⏪ Revert changes
- [ ] 🧪 New tests or updates to existing tests
